### PR TITLE
When user doesn't set principal or secret, return default empty Crede…

### DIFF
--- a/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/CredentialFactory.java
+++ b/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/CredentialFactory.java
@@ -13,9 +13,13 @@ public class CredentialFactory {
     MesosConfigProperties mesosConfig;
 
     public Protos.Credential create() {
-        return Protos.Credential.newBuilder()
-                .setPrincipal(mesosConfig.getPrincipal())
-                .setSecret(ByteString.copyFrom(mesosConfig.getSecret().getBytes()))
-                .build();
+        if (mesosConfig.getPrincipal() != null && mesosConfig.getSecret() != null) {
+            return Protos.Credential.newBuilder()
+                    .setPrincipal(mesosConfig.getPrincipal())
+                    .setSecret(ByteString.copyFrom(mesosConfig.getSecret().getBytes()))
+                    .build();
+        } else {
+            return Protos.Credential.getDefaultInstance();
+        }
     }
 }


### PR DESCRIPTION
…ntial proto.

The proto doesn't like accepting nulls. And a value is deemed as a valid credential.