### PR TITLE
Add property for CommandInfo URI's field.

### DIFF
--- a/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/CommandInfoMesosProtoFactory.java
+++ b/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/CommandInfoMesosProtoFactory.java
@@ -4,7 +4,6 @@ import com.containersolutions.mesos.scheduler.config.MesosConfigProperties;
 import org.apache.mesos.Protos;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -18,15 +17,13 @@ public class CommandInfoMesosProtoFactory implements MesosProtoFactory<Protos.Co
         Optional<String> command = Optional.ofNullable(mesosConfig.getCommand());
         builder.setShell(command.isPresent());
         command.ifPresent(builder::setValue);
-        Optional<List<String>> uris = Optional.ofNullable(mesosConfig.getUri());
-        uris.ifPresent(list -> builder.addAllUris(list.stream().map(uri -> Protos.CommandInfo.URI.newBuilder().setValue(uri).build()).collect(Collectors.toList())));
+        builder.addAllUris(mesosConfig.getUri().stream().map(uri -> Protos.CommandInfo.URI.newBuilder().setValue(uri).build()).collect(Collectors.toList()));
 
         mesosConfig.getEnvironment().entrySet().stream()
                 .map(kv -> Protos.Environment.Variable.newBuilder().setName(kv.getKey()).setValue(kv.getValue()).build())
                 .collect(Collectors.collectingAndThen(
                         Collectors.toList(),
                         variables -> builder.setEnvironment(Protos.Environment.newBuilder().addAllVariables(variables))));
-
         return builder;
     }
 }

--- a/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/CommandInfoMesosProtoFactory.java
+++ b/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/CommandInfoMesosProtoFactory.java
@@ -4,6 +4,7 @@ import com.containersolutions.mesos.scheduler.config.MesosConfigProperties;
 import org.apache.mesos.Protos;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -17,6 +18,8 @@ public class CommandInfoMesosProtoFactory implements MesosProtoFactory<Protos.Co
         Optional<String> command = Optional.ofNullable(mesosConfig.getCommand());
         builder.setShell(command.isPresent());
         command.ifPresent(builder::setValue);
+        Optional<List<String>> uris = Optional.ofNullable(mesosConfig.getUri());
+        uris.ifPresent(list -> builder.addAllUris(list.stream().map(uri -> Protos.CommandInfo.URI.newBuilder().setValue(uri).build()).collect(Collectors.toList())));
 
         mesosConfig.getEnvironment().entrySet().stream()
                 .map(kv -> Protos.Environment.Variable.newBuilder().setName(kv.getKey()).setValue(kv.getValue()).build())

--- a/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/config/MesosConfigProperties.java
+++ b/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/config/MesosConfigProperties.java
@@ -3,6 +3,7 @@ package com.containersolutions.mesos.scheduler.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @ConfigurationProperties(prefix = "mesos")
@@ -13,6 +14,7 @@ public class MesosConfigProperties {
     private ResourcesConfigProperties resources = new ResourcesConfigProperties();
     private String principal;
     private String secret;
+    private List<String> uri;
 
     public String getRole() {
         return role;
@@ -60,5 +62,13 @@ public class MesosConfigProperties {
 
     public void setSecret(String secret) {
         this.secret = secret;
+    }
+
+    public List<String> getUri() {
+        return uri;
+    }
+
+    public void setUri(List<String> uri) {
+        this.uri = uri;
     }
 }

--- a/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/config/MesosConfigProperties.java
+++ b/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/config/MesosConfigProperties.java
@@ -2,6 +2,7 @@ package com.containersolutions.mesos.scheduler.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +15,7 @@ public class MesosConfigProperties {
     private ResourcesConfigProperties resources = new ResourcesConfigProperties();
     private String principal;
     private String secret;
-    private List<String> uri;
+    private List<String> uri = new ArrayList<>();
 
     public String getRole() {
         return role;


### PR DESCRIPTION
Can now upload files to the sandbox directory of a task.
Working example:
```
spring.application.name=kibana
mesos.framework.name=kibana
mesos.resources.scale=3
mesos.resources.cpus=0.5
mesos.resources.mem=256
mesos.resources.ports=true
mesos.resources.ports.UI_5061=ANY
mesos.uri[0]=https://gist.githubusercontent.com/philwinder/773480c362663dde8411/raw/elasticsearch.yml
mesos.uri[1]=/etc/hosts

mesos.command=kibana --port=$UI_5061 --elasticsearch http://172.17.0.2:9200
mesos.docker.parameter.expose=$UI_5061
mesos.docker.network=BRIDGE
mesos.docker.image=kibana:latest
```

Which will download the gist and the /etc/hosts file and place them in the sandbox.
Fixes #34 