### PR TITLE
Framework id is being written as a full protobuf object, not a string

### DIFF
--- a/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/state/StateRepositoryZookeeper.java
+++ b/spring-boot-starter-mesos/src/main/java/com/containersolutions/mesos/scheduler/state/StateRepositoryZookeeper.java
@@ -42,14 +42,14 @@ public class StateRepositoryZookeeper implements StateRepository {
         if (value.length == 0) {
             return Optional.empty();
         }
-        return Optional.of(Protos.FrameworkID.newBuilder().setValue(new String(value)).build());
+        return Optional.of(Protos.FrameworkID.newBuilder().setValue(((String) SerializationUtils.deserialize(value))).build());
     }
 
     @EventListener
     public void onFrameworkRegistered(FrameworkRegistreredEvent event) {
         logger.debug("Received frameworkId=" + event.getFrameworkID().getValue());
         frameworkId.set(event.getFrameworkID());
-        set("frameworkid", frameworkId.get());
+        set("frameworkid", frameworkId.get().getValue());
     }
 
     @EventListener


### PR DESCRIPTION
Sometimes there is state left over in zookeeper when shutting down a framework. When a new framework starts, it thinks there are three running tasks, when in fact there are none.

To replicate (confirmed using Kibana on real life Mesos cluster on AWS):
1. Start framework with marathon.
2. Use marathon to destroy framework
3. Start framework with marathon.
The new framework will then kill all previous tasks and not start any new ones.

Work around:
Delete the `/${framework_name}/tasks` zNode in zookeeper.